### PR TITLE
Incorporate support for rust changes

### DIFF
--- a/Preferences/Comments.tmPreferences
+++ b/Preferences/Comments.tmPreferences
@@ -37,6 +37,41 @@
 */</string>
 			</dict>
 		</array>
+		<key>smartTypingPairs</key>
+		<array>
+			<array>
+				<string>"</string>
+				<string>"</string>
+			</array>
+			<array>
+				<string>(</string>
+				<string>)</string>
+			</array>
+			<array>
+				<string>{</string>
+				<string>}</string>
+			</array>
+			<array>
+				<string>[</string>
+				<string>]</string>
+			</array>
+			<array>
+				<string>“</string>
+				<string>”</string>
+			</array>
+			<array>
+				<string>‘</string>
+				<string>’</string>
+			</array>
+			<array>
+				<string>&lt;</string>
+				<string>&gt;</string>
+			</array>
+			<array>
+				<string>`</string>
+				<string>`</string>
+			</array>
+		</array>
 	</dict>
 	<key>uuid</key>
 	<string>C4C70D88-6B26-45A3-828B-13FDB8F24D2E</string>

--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ This bundle is licensed under the MIT License (LICENSE).
 
 Copyright (c) 2012 [Tom Ellis](http://www.webmuse.co.uk/)
 Copyright (c) 2014 [Elia Schito](http://elia.schito.me/)
+Copyright (c) 2015 [Carol (Nichols || Goulding)](http://carol-nichols.com)

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -64,6 +64,10 @@
 			<string>#string_literal</string>
 		</dict>
 		<dict>
+			<key>include</key>
+			<string>#raw_string</string>
+		</dict>
+		<dict>
 			<key>comment</key>
 			<string>Floating point number (fraction)</string>
 			<key>match</key>
@@ -545,6 +549,17 @@
 					<string>#escaped_character</string>
 				</dict>
 			</array>
+		</dict>
+		<key>raw_string</key>
+		<dict>
+			<key>begin</key>
+			<string>r#"</string>
+			<key>comment</key>
+			<string>Raw string</string>
+			<key>end</key>
+			<string>"#</string>
+			<key>name</key>
+			<string>string.unquoted.rust</string>
 		</dict>
 		<key>type_params</key>
 		<dict>

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -616,7 +616,7 @@
 			<key>comment</key>
 			<string>Built-in type</string>
 			<key>match</key>
-			<string>\b(bool|char|uint|int|u8|u16|u32|u64|i8|i16|i32|i64|f32|f64|str|Self)\b</string>
+			<string>\b(bool|char|usize|isize|u8|u16|u32|u64|i8|i16|i32|i64|f32|f64|str|Self)\b</string>
 			<key>name</key>
 			<string>storage.type.rust</string>
 		</dict>


### PR DESCRIPTION
Hi! I know you haven't updated your tmbundle in almost a year, but I'll toss these changes your way and hope :)

I've been using these changes for a bit and they've made me happy:

* Added support for syntax highlighting raw strings (`r#"..."#`)
* Updated the built-in types to have `usize/isize` instead of `uint/int` since The Great Int Type Renaming of 2014
* In order to make lifetime typing nicer, changed `'` to *not* be a smart typing pair and `<>` *to* be one

Thanks!! :heart: 